### PR TITLE
Fixed memory leak in SignalSenderKeyName

### DIFF
--- a/libsignal-protocol-swift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/libsignal-protocol-swift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/libsignal-protocol-swift/Misc/SignalSenderKeyName.swift
+++ b/libsignal-protocol-swift/Misc/SignalSenderKeyName.swift
@@ -44,6 +44,10 @@ public final class SignalSenderKeyName {
         address.pointee = signal_protocol_sender_key_name(group_id: groupPointer, group_id_len: count, sender: sender.signalAddress.pointee)
     }
 
+    deinit {
+        address.deallocate()
+    }
+
     /**
      Create an a sender key name from a pointer to a libsignal-protocol-c address.
      - parameter address: The pointer to the address


### PR DESCRIPTION
address property was not properly deallocated, leading to memory leak. 

![Capture d’écran 2022-10-17 à 15 04 12](https://user-images.githubusercontent.com/8861304/196184354-1c507c3a-b673-48d4-9d06-a27446527d57.png)
